### PR TITLE
Add Azure Service Groups video link to references

### DIFF
--- a/blog/2025-07-06-servicegroupsazapi/index.mdx
+++ b/blog/2025-07-06-servicegroupsazapi/index.mdx
@@ -357,3 +357,4 @@ This code creates a structured hierarchy of service groups, each representing a 
 - [Platform Engineering Best Practices](https://learn.microsoft.com/platform-engineering/?WT.mc_id=AZ-MVP-5004796)
 - [Team Topologies](https://teamtopologies.com/)
 - [Azure Well-Architected Framework](https://learn.microsoft.com/azure/well-architected/?WT.mc_id=AZ-MVP-5004796)
+- [Azure Service Groups - What and Why?](https://youtu.be/64uj-syYv5Y)


### PR DESCRIPTION
Appended a YouTube link titled 'Azure Service Groups - What and Why?' to the references section for additional context and learning resources.