### PR TITLE
Fix frontmatter formatting in MCP blog post

### DIFF
--- a/blog/2025-07-01-learndocsmcp/index.mdx
+++ b/blog/2025-07-01-learndocsmcp/index.mdx
@@ -1,25 +1,25 @@
 ---
- title: Model Context Protocol (MCP) in VS Code with Microsoft Learn
- metaDescription: Connect VS Code to Microsoft Learn's semantic search with MCP to ground AI responses in up-to-date Azure documentation.
- tags:
-   - Azure
- categories:
-   - Azure
- authors:
-   - Luke
- slug: azure/mcp-vscode-microsoft-learn
- keywords:
-   - Azure
-   - Model Context Protocol
-   - MCP
-   - Visual Studio Code
-   - Microsoft Learn
-   - Semantic Search
-   - Copilot Chat Modes
-   - AI Tools
- description: Learn how to connect VS Code to Microsoft Learn's semantic search using MCP to ground AI responses in current Azure documentation.
- date: 2025-06-30T22:32:59.580Z
- ---
+title: Model Context Protocol (MCP) in VS Code with Microsoft Learn
+metaDescription: Connect VS Code to Microsoft Learn's semantic search with MCP to ground AI responses in up-to-date Azure documentation.
+tags:
+  - Azure
+categories:
+  - Azure
+authors:
+  - Luke
+slug: azure/mcp-vscode-microsoft-learn
+keywords:
+  - Azure
+  - Model Context Protocol
+  - MCP
+  - Visual Studio Code
+  - Microsoft Learn
+  - Semantic Search
+  - Copilot Chat Modes
+  - AI Tools
+description: Learn how to connect VS Code to Microsoft Learn's semantic search using MCP to ground AI responses in current Azure documentation.
+date: 2025-06-30T22:32:59.580Z
+---
 
  The Model Context Protocol is an open standard that enables developers to build secure, two-way connections between their data sources and AI-powered tools. The architecture is straightforward: Developers can expose their data through MCP servers or build AI applications _(MCP clients)_ that connect to these servers.
 


### PR DESCRIPTION
Removed extra spaces before frontmatter keys in the blog post index.mdx file to ensure proper parsing and consistency.