### PR TITLE
Add docs fetch tool feature to MCP blog post

### DIFF
--- a/blog/2025-07-01-learndocsmcp/index.mdx
+++ b/blog/2025-07-01-learndocsmcp/index.mdx
@@ -38,6 +38,7 @@ date: 2025-06-30T22:32:59.580Z
  - Semantic search: Uses vector search to retrieve contextually relevant documentation for a given query.
  - Optimized Chunking: Returns up to 10 high-quality content chunks _(each max 500 tokens)_, with article titles, URLs, and self-contained content excerpts.
  - Continuously updated content: Access the latest Microsoft documentation as it is published.
+ - The ability to fetch full pages of documentation using the `microsoft_docs_fetch` tool, which returns the content as clean markdown with headings, code blocks, tables, and links.
 
  It's worth noting as we go into the demo that MCP servers expose the tools and resources but do not run any reasoning logic themselves; tool invocation is determined by the host application and model configuration. You can control this behavior in the description of your MCP servers and the crafting of your system and user prompts, you will see some of this in our demo shortly.
 


### PR DESCRIPTION
Mentioned the new capability to fetch full documentation pages using the `microsoft_docs_fetch` tool, which returns content as clean markdown. This highlights an additional feature available in MCP for improved documentation retrieval.