### PR TITLE
Clarify MCP server support in blog post

### DIFF
--- a/blog/2025-08-10-akahumcpapim/index.mdx
+++ b/blog/2025-08-10-akahumcpapim/index.mdx
@@ -22,11 +22,11 @@ description: Expose Akahu open banking APIs through Azure API Management as an M
 date: 2025-08-10T07:59:51.617Z
 ---
 
-A recent release to Azure API Management is - MCP server support, the ability to expose an existing MCP server through your API Management instance, and expose a [REST API in API Management as an MCP server](https://learn.microsoft.com/en-us/azure/api-management/export-rest-mcp-server?WT.mc_id=AZ-MVP-5004796).
+A recent release to Azure API Management is - MCP server support, the ability to expose a [REST API in API Management as an MCP server](https://learn.microsoft.com/en-us/azure/api-management/export-rest-mcp-server?WT.mc_id=AZ-MVP-5004796).
 
 {/* truncate */}
 
-Today we are going to look at how to expose an existing MCP server through your API Management instance, with [Akahu](https://www.akahu.nz/).
+Today we are going to look at how to expose an REST API as an MCP server through your API Management instance, with [Akahu](https://www.akahu.nz/) APIs as my example.
 
 ## 🚀 Overview
 


### PR DESCRIPTION
Updated wording to clarify that the example demonstrates exposing a REST API as an MCP server in Azure API Management, specifically using Akahu APIs. Removed redundant phrasing about existing MCP server exposure.