### PR TITLE
Update Docusaurus dependencies and MCP Server link

### DIFF
--- a/blog/2025-09-27-learndocsmcpsk/index.mdx
+++ b/blog/2025-09-27-learndocsmcpsk/index.mdx
@@ -432,7 +432,7 @@ This ensures users get current information rather than potentially outdated trai
 
 This turned out simpler than expected. No scraping, no stale docs, no index maintenance - just direct access to Microsoft's current documentation through their Learn MCP server.
 
-To learn more about Microsoft Learn MCP Server and its capabilities, visit [https://aka.ms/MSLearnMCPServer](https://aka.ms/MSLearnMCPServer).
+To learn more about Microsoft Learn MCP Server and its capabilities, visit [https://aka.ms/MSLearnMCPServer](https://learn.microsoft.com/training/support/mcp?wt.mc_id=msftlearngeneral_learnmcpserver_thirdpartysocial_wwl&WT.mc_id=AZ-MVP-5004796).
 
 Beyond my content discovery use case, this approach works well for:
 - Support chatbots needing current Azure documentation

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "3.8.1",
-    "@docusaurus/preset-classic": "3.8.1",
-    "@docusaurus/theme-mermaid": "3.8.1",
+    "@docusaurus/core": "3.9.1",
+    "@docusaurus/preset-classic": "3.9.1",
+    "@docusaurus/theme-mermaid": "3.9.1",
     "@mdx-js/react": "^3.1.0",
     "@algolia/client-search": "^5.27.0",
     "clsx": "^2.1.1",
@@ -29,8 +29,8 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.8.1",
-    "@docusaurus/types": "3.8.1",
+    "@docusaurus/module-type-aliases": "3.9.1",
+    "@docusaurus/types": "3.9.1",
     "@types/react": "^18.3.4"
   },
   "browserslist": {


### PR DESCRIPTION
Upgraded Docusaurus packages to version 3.9.1 in package.json for improved stability and features. Updated the Microsoft Learn MCP Server link in the blog post to point to the official documentation page.