### PR TITLE
Move onBrokenMarkdownLinks to markdown hooks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,7 +26,6 @@ const config = {
   deploymentBranch: "gh-pages",
   trailingSlash: true,
   onBrokenLinks: "warn",
-  onBrokenMarkdownLinks: "warn",
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
@@ -129,6 +128,9 @@ const config = {
   markdown: {
     mermaid: true,
     format: "detect",
+    hooks: {
+      onBrokenMarkdownLinks: "warn",
+    },
   },
 
   plugins: [


### PR DESCRIPTION
Relocated the onBrokenMarkdownLinks configuration from the root level to the markdown.hooks object for improved organization and alignment with Docusaurus config structure.