### PR TITLE
Allow query and JSON URLs in robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -4,6 +4,8 @@ Sitemap: https://luke.geek.nz/sitemap.xml
 ## Explicitly allow Algolia Crawler
 User-agent: Algolia Crawler
 Allow: /
+Allow: /*?
+Allow: /*.json
 # Optional: keep polite crawling
 Crawl-delay: 1
 


### PR DESCRIPTION
Permit crawlers to access URLs with query strings and .json endpoints by adding Allow: /*? and Allow: /*.json to static/robots.txt. This ensures crawlers (e.g., Algolia Crawler) can index dynamic or API-backed content while keeping the existing crawl-delay.