### PR TITLE
Adjust Docusaurus warnings, icon, and styles

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -28,7 +28,7 @@ const config = {
   projectName: "lukemurraynz", // Usually your repo name.
   deploymentBranch: "gh-pages",
   trailingSlash: true,
-  onBrokenLinks: "warn",
+  onBrokenLinks: isProd ? "throw" : "warn",
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
@@ -223,7 +223,7 @@ const config = {
           blogTitle: "Luke's Tech Blog - Unleashing the power of the cloud and other technologies!",
           blogDescription: "Follow Luke, Microsoft Azure MVP, on a journey through the latest Microsoft and Azure Cloud innovations. Learn, explore, and stay ahead in the fast-moving world of cloud computing.",
           postsPerPage: 5,
-          onUntruncatedBlogPosts: 'ignore',
+          onUntruncatedBlogPosts: 'warn',
           blogSidebarTitle: "Recent posts",
           blogSidebarCount: 5,
           feedOptions: {
@@ -342,8 +342,8 @@ const config = {
             position: "right",
             className: "navbar-icon",
             "aria-label": "X",
-            html: `<svg height="20" width="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-            <path fill-rule="evenodd" d="M10 8.586l4.293-4.293a1 1 0 011.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 011.414-1.414L10 8.586z" clip-rule="evenodd" />
+            html: `<svg height="20" width="20" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
           </svg>`,
           },
         

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -193,16 +193,6 @@ div[class^=announcementBar][role="banner"] {
   outline-offset: 2px;
 }
 
-.toc_container,
-.toc_title,
-.toc_list,
-.toc_number,
-.toc_depth_1,
-.toc_depth_2,
-.toc_depth_3 {
-  display: none !important;
-}
-
 .header-rss-link:hover {
   opacity: 0.6;
 }
@@ -280,6 +270,11 @@ div[class^=announcementBar][role="banner"] {
 
 [data-theme='dark'] .cookie-consent-btn--accept {
   color: #121212;
+}
+
+[data-theme='dark'] .cookie-consent-btn--decline {
+  color: #e0e0e0;
+  border-color: #555;
 }
 
 .cookie-consent-btn--decline {


### PR DESCRIPTION
Tighten build checks and tweak UI: onBrokenLinks now throws in production (isProd), and onUntruncatedBlogPosts changed from 'ignore' to 'warn' to surface truncated posts. Replace the navbar SVG with an updated icon SVG. Restore the table-of-contents visibility by removing the CSS that hid .toc_* selectors, and add dark-theme styles for the cookie-consent decline button.